### PR TITLE
Use @ApiModel.value as alternate type name for serialization

### DIFF
--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/ApiModelReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/ApiModelReaderSpec.groovy
@@ -70,9 +70,10 @@ class ApiModelReaderSpec extends Specification {
 //      println model.subTypes()
   }
 
-  def "Annotated model"() {
+  def "Annotated model properties"() {
     given:
-      RequestMappingContext context = contextWithApiDescription(dummyHandlerMethod('methodWithModelAnnotations'))
+      RequestMappingContext context = contextWithApiDescription(dummyHandlerMethod
+              ('methodWithModelPropertyAnnotations'))
       SwaggerGlobalSettings settings = new SwaggerGlobalSettings()
       def modelConfig = new SwaggerModelsConfiguration()
       def typeResolver = new TypeResolver()
@@ -122,7 +123,29 @@ class ApiModelReaderSpec extends Specification {
       models['FunkyBusiness'].getQualifiedType() == 'com.mangofactory.swagger.dummy.DummyModels$FunkyBusiness'
   }
 
-  def "Should pull models from operation's ApiResponse annotations"() {
+  def "Annotated model"() {
+    given:
+      RequestMappingContext context = contextWithApiDescription(dummyHandlerMethod('methodWithModelAnnotations'))
+      SwaggerGlobalSettings settings = new SwaggerGlobalSettings()
+      def modelConfig = new SwaggerModelsConfiguration()
+      def typeResolver = new TypeResolver()
+      settings.alternateTypeProvider = modelConfig.alternateTypeProvider(typeResolver)
+      settings.ignorableParameterTypes = new SpringSwaggerConfig().defaultIgnorableParameterTypes()
+      context.put("swaggerGlobalSettings", settings)
+    when:
+      ApiModelReader apiModelReader = new ApiModelReader(modelProvider())
+      apiModelReader.execute(context)
+      Map<String, Object> result = context.getResult()
+
+    then:
+      Map<String, Model> models = result.get("models")
+      Model model = models['AlternateBusinessModelName']
+      model.getId() == 'AlternateBusinessModelName'
+      model.getName() == 'AlternateBusinessModelName'
+      model.getQualifiedType() == 'com.mangofactory.swagger.dummy.DummyModels$NamedBusinessModel'
+  }
+
+    def "Should pull models from operation's ApiResponse annotations"() {
     given:
 
       RequestMappingContext context = contextWithApiDescription(dummyHandlerMethod('methodAnnotatedWithApiResponse'), null)

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
@@ -206,7 +206,12 @@ public class DummyClass {
   }
 
   @ResponseBody
-  public DummyModels.AnnotatedBusinessModel methodWithModelAnnotations() {
+  public DummyModels.AnnotatedBusinessModel methodWithModelPropertyAnnotations() {
+    return null;
+  }
+
+  @ResponseBody
+  public DummyModels.NamedBusinessModel methodWithModelAnnotations() {
     return null;
   }
 

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyModels.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyModels.java
@@ -37,7 +37,6 @@ public class DummyModels {
     }
   }
 
-  @ApiModel(value = "Swagger annotated model", description = "More descriptive model text")
   public class AnnotatedBusinessModel {
     //TODO - @ApiModelProperty has no effect on members - only setters
 //        @ApiModelProperty(value = "The name of this business", required = true)
@@ -64,8 +63,11 @@ public class DummyModels {
     }
   }
 
-  public class CorporationModel extends BusinessModel {
+  @ApiModel(value = "AlternateBusinessModelName", description = "Swagger annotated model")
+  public class NamedBusinessModel extends BusinessModel {
+  }
 
+  public class CorporationModel extends BusinessModel {
   }
 
   public class Paginated<T> {


### PR DESCRIPTION
Replaces the ResolvedType with @ApiModel.value if present

closes #382 

