### PR TITLE
Add support for @RequestPart annotation 

### DIFF
--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/ApiModelReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/ApiModelReader.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.method.HandlerMethod;
 
 import java.lang.annotation.Annotation;
@@ -182,7 +183,7 @@ public class ApiModelReader implements Command<RequestMappingContext> {
     for (int i = 0; i < annotations.length; i++) {
       Annotation[] pAnnotations = annotations[i];
       for (Annotation annotation : pAnnotations) {
-        if (annotation instanceof RequestBody) {
+        if (annotation instanceof RequestBody || annotation instanceof RequestPart) {
           ResolvedMethodParameter pType = parameterTypes.get(i);
           if (!settings.getIgnorableParameterTypes()
                   .contains(pType.getResolvedParameterType().getErasedType())) {

--- a/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ParameterTypeReader.java
+++ b/swagger-springmvc/src/main/java/com/mangofactory/swagger/readers/operation/parameter/ParameterTypeReader.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.lang.annotation.Annotation;
@@ -45,6 +46,8 @@ public class ParameterTypeReader implements Command<RequestMappingContext> {
           return "query";
         } else if (annotation instanceof RequestHeader) {
           return "header";
+        } else if (annotation instanceof RequestPart) {
+          return "form";
         }
       }
     }

--- a/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/ParameterTypeReaderSpec.groovy
+++ b/swagger-springmvc/src/test/groovy/com/mangofactory/swagger/readers/operation/parameter/ParameterTypeReaderSpec.groovy
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.ModelAttribute
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.method.HandlerMethod
 import org.springframework.web.multipart.MultipartFile
 import spock.lang.Specification
@@ -48,6 +49,7 @@ class ParameterTypeReaderSpec extends Specification {
       [:] as ModelAttribute | Integer       | "body"
       [:] as RequestHeader  | Integer       | "header"
       [:] as RequestParam   | Integer       | "query"
+      [:] as RequestPart    | Integer       | "form"
       null                  | Integer       | "body"
       null                  | MultipartFile | "form"
   }

--- a/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
+++ b/swagger-springmvc/src/test/java/com/mangofactory/swagger/dummy/DummyClass.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -227,6 +228,18 @@ public class DummyClass {
 
   public void methodParameterWithRequestBodyAnnotation(
           @RequestBody DummyModels.BusinessModel model,
+          HttpServletResponse response,
+          DummyModels.AnnotatedBusinessModel annotatedBusinessModel) {
+  }
+
+  public void methodParameterWithRequestPartAnnotation(
+          @RequestPart DummyModels.BusinessModel model,
+          HttpServletResponse response,
+          DummyModels.AnnotatedBusinessModel annotatedBusinessModel) {
+  }
+
+  public void methodParameterWithRequestPartAnnotationOnSimpleType(
+          @RequestPart String model,
           HttpServletResponse response,
           DummyModels.AnnotatedBusinessModel annotatedBusinessModel) {
   }


### PR DESCRIPTION
Add support for `@RequestPart` annotation which means the request content-type would be multipart/form-data, which must have paramType of 'form' in swagger-ui.

This is for Issue #588

Some caveats I've found when using `@RequestPart` on things other than files...

* Currently swagger-ui renders paramType 'form' as `<input type="text" />` instead of `<textarea>`. I plan to submit a pull request to fix that as well.
* Through swagger-ui, the content-type for the `@RequestPart`'s that aren't files are not set (limitation of HTML forms), so in order for spring to properly handle a request with a `@RequestPart` that isn't a file, I had to use a custom MultipartResolver to detect if the content type should be `application/json` if it was null.
